### PR TITLE
Added dogecoind error code as a property on the Error instance when an error occurs

### DIFF
--- a/lib/dogecoin.js
+++ b/lib/dogecoin.js
@@ -1,4 +1,3 @@
-
 var http = require('http')
 ,   api  = require('./commands')
 
@@ -71,7 +70,7 @@ Client.prototype = {
                 }
                 if (data.error) {
                     var err = new Error(JSON.stringify(data))
-                    err.code = date.error.code
+                    err.code = data.error.code
                     return fn(err)
                 }
                 fn(null, data.result || data)


### PR DESCRIPTION
I'm currently writing a system that needs to unlock a wallet when the RPC response indicates an unlock is required. The easiest way I found to do this is to observe the error code when a request fails. Perhaps we could expose all the error object's fields on the Error instance.
