### PR TITLE
Fixed bug where if result is integer and zero an object is returned.

### DIFF
--- a/lib/dogecoin.js
+++ b/lib/dogecoin.js
@@ -80,7 +80,7 @@ Client.prototype = {
                       return fn(err)
                     }
                 }
-                fn(null, data.result || data)
+                fn(null, data.result !== null ? data.result : data)
             })
         })
 


### PR DESCRIPTION
This bug manifested when you called `getBalance` and the resulting
balance was zero. Instead of a return value of zero, you would get
the response JSON object. This is because

```
fn(null, data.result || data)
```

will ignore data.result if data.result === 0.
