### PR TITLE
Removing preinstall script that should not be there

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,5 @@
     "engines": { "node": ">= 0.4.0" },
     "devDependencies": {
         "nodeunit": "*"
-    },
-    "scripts": {
-        "preinstall": "npm i -g nodeunit"
     }
 }


### PR DESCRIPTION
This forces this to be ran as part of npm install. You should not be requiring people to have a globally installed test suite as part of normal program operation. This is a fatal error if your library is listed as a dependency. 
